### PR TITLE
Hack to allow building on linux

### DIFF
--- a/selfutil_patched/selfutil.cpp
+++ b/selfutil_patched/selfutil.cpp
@@ -5,6 +5,8 @@
 
 #include "selfutil.h"
 #include <filesystem>
+#include <stdio.h>
+#include <string.h>
 
 //
 // //
@@ -16,6 +18,10 @@
 
 // notes :
 // debug needs to be configured as Active x86
+
+#ifdef __unix
+#define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
+#endif
 
 
 void print_usage()


### PR DESCRIPTION
This project is getting a lot of attention since Bloodborne on Shadps4 is now starting to be semi playable. Sadly it does not currently build on Linux so this is a small workaround to fix it. 